### PR TITLE
Changed Metadata label to SEO in page context menu

### DIFF
--- a/l10n/en.json
+++ b/l10n/en.json
@@ -88,7 +88,7 @@
     "label.node.action.error": "Error Pages",
     "label.node.action.error.intro": "Set error pages for your site to have a more friendly experience.",
     "label.node.action.go": "View",
-    "label.node.action.meta": "Metadata",
+    "label.node.action.meta": "SEO",
     "label.node.action.meta.intro": "Set the metadata for this page to improve its visibility in search engines and social media.",
     "label.node.action.preview": "Preview",
     "label.node.action.publish": "Publish",

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -86,7 +86,7 @@
     "label.node.action.error": "Foutenpagina's",
     "label.node.action.error.intro": "Stel de foutenpagina's in om een betere gebruikerservaring aan te bieden.",
     "label.node.action.go": "Bekijk",
-    "label.node.action.meta": "Meta",
+    "label.node.action.meta": "SEO",
     "label.node.action.meta.intro": "Stel de meta tags in voor je pagina. Dit verbeterd de integratie met zoekrobots en sociale netwerken.",
     "label.node.action.preview": "Preview",
     "label.node.action.publish": "Publiceren",


### PR DESCRIPTION
Because clients don't have a clue what meta means.
